### PR TITLE
Remove redundant ConvertHeadwordsToLowercase functionality

### DIFF
--- a/backend/ctl/dictimport/dictparser/html/parser.go
+++ b/backend/ctl/dictimport/dictparser/html/parser.go
@@ -138,14 +138,6 @@ func parseArticle(body string, settings dictionary.IndexSettings) (dictparser.Ar
 		}
 	}
 
-	if settings.ConvertHeadwordsToLowercase {
-		for i := range hws {
-			hws[i] = strings.ToLower(hws[i])
-		}
-		for i := range hwsalt {
-			hwsalt[i] = strings.ToLower(hwsalt[i])
-		}
-	}
 
 	body = strings.ReplaceAll(body, "<sup", "\u200b<sup")
 	return dictparser.Article{

--- a/backend/dictionary/dictionary.go
+++ b/backend/dictionary/dictionary.go
@@ -252,7 +252,6 @@ func InitDictionaries() error {
 			scanURL:   "https://knihi.com/none/Etymalahicny_slounik_bielaruskaj_movy_zip.html",
 			slugifier: "none",
 			indexSettings: IndexSettings{
-				ConvertHeadwordsToLowercase:      true,
 				DictProvidesIDs:                  true,
 				DictProvidesIDsWithoutDuplicates: true,
 			},

--- a/backend/dictionary/index_settings.go
+++ b/backend/dictionary/index_settings.go
@@ -2,7 +2,6 @@ package dictionary
 
 type IndexSettings struct {
 	PrependContentWithTitle          bool
-	ConvertHeadwordsToLowercase      bool
 	DictProvidesIDs                  bool
 	DictProvidesIDsWithoutDuplicates bool
 }


### PR DESCRIPTION
The ConvertHeadwordsToLowercase setting was redundant since all headwords are already converted to lowercase during the import process in dictimport.go. This removes the unnecessary parser-level conversion.

🤖 Generated with [Claude Code](https://claude.ai/code)