### PR TITLE
Add ґ to rune order map after г

### DIFF
--- a/backend/textutil/sortkey.go
+++ b/backend/textutil/sortkey.go
@@ -6,7 +6,7 @@ import (
 )
 
 const runeOrder = " aäąàbcćdeęfghijklłmnńoöópqrsßśtuüvwxyzźż" +
-	"абвгдеёжзіийклмнопрстуўфхцчшщъыьэюя"
+	"абвгґдеёжзіийклмнопрстуўфхцчшщъыьэюя"
 
 var runeOrderMap = map[rune]byte{}
 

--- a/backend/textutil/sortkey_test.go
+++ b/backend/textutil/sortkey_test.go
@@ -7,6 +7,8 @@ func TestSortKey(t *testing.T) {
 		{"а", "аб"},
 		{"а", "б"},
 		{"аба", "аб’едкі"},
+		{"г", "ґ"},
+		{"ґ", "д"},
 	}
 
 	for _, p := range pairs {


### PR DESCRIPTION
Add the lowercased Ґ (ґ) to the Cyrillic alphabet sequence in the rune order map to ensure proper sorting of Ukrainian letters in Belarusian text.

🤖 Generated with [Claude Code](https://claude.ai/code)